### PR TITLE
Fix compilation errors with GCC

### DIFF
--- a/win/dialog.cpp
+++ b/win/dialog.cpp
@@ -353,7 +353,7 @@ INT_PTR Dialog::DialogProcDefault(HWND hwnd, UINT uMsg,
     case WM_MOUSEWHEEL: {
       LRESULT result = OnMouseEvent(uMsg, wParam, lParam);
       if (result != -1) {
-        ::SetWindowLongPtrW(hwnd, DWL_MSGRESULT, result);
+        ::SetWindowLongPtrW(hwnd, DWLP_MSGRESULT, result);
         return TRUE;
       }
       break;
@@ -366,7 +366,7 @@ INT_PTR Dialog::DialogProcDefault(HWND hwnd, UINT uMsg,
     case WM_NOTIFY: {
       LRESULT result = OnNotify(wParam, reinterpret_cast<LPNMHDR>(lParam));
       if (result) {
-        ::SetWindowLongPtr(hwnd, DWL_MSGRESULT, result);
+        ::SetWindowLongPtr(hwnd, DWLP_MSGRESULT, result);
         return TRUE;
       }
       break;

--- a/win/taskbar.cpp
+++ b/win/taskbar.cpp
@@ -25,9 +25,6 @@ SOFTWARE.
 #include "taskbar.h"
 #include "version.h"
 
-class win::Taskbar Taskbar;
-class win::TaskbarList TaskbarList;
-
 const DWORD WM_TASKBARCALLBACK = WM_APP + 0x15;
 const DWORD WM_TASKBARCREATED = ::RegisterWindowMessage(L"TaskbarCreated");
 const DWORD WM_TASKBARBUTTONCREATED = ::RegisterWindowMessage(L"TaskbarButtonCreated");

--- a/win/window.h
+++ b/win/window.h
@@ -24,7 +24,9 @@ SOFTWARE.
 
 #pragma once
 
-//#include <windows.h>
+#include <string>
+
+#include <windows.h>
 
 namespace win {
 


### PR DESCRIPTION
Hello. I created a simple project with empty window by now, compiled with GCC 7.2.0.
There were some compilation issues, here's a patch.

Tested compiling Taiga with these changes, all went fine.