### PR TITLE
Version-related changes

### DIFF
--- a/win/ctrl/listview.cpp
+++ b/win/ctrl/listview.cpp
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 #include "../common_controls.h"
-#include "../version.h"
 
 namespace win {
 
@@ -66,10 +65,6 @@ int ListView::InsertColumn(int index, int width, int width_min, int align,
   lvc.mask = LVCF_FMT | LVCF_TEXT | LVCF_WIDTH |
              (width_min ? LVCF_MINWIDTH : 0);
   lvc.pszText = const_cast<LPWSTR>(text);
-
-  if (GetVersion() < kVersionVista)
-    lvc.cx = lvc.cxMin;
-
   return ListView_InsertColumn(window_, index, &lvc);
 }
 
@@ -87,7 +82,7 @@ int ListView::InsertGroup(int index, LPCWSTR text,
   lvg.mask = LVGF_HEADER | LVGF_GROUPID;
   lvg.pszHeader = const_cast<LPWSTR>(text);
 
-  if (collapsable && GetVersion() >= kVersionVista) {
+  if (collapsable) {
     lvg.mask |= LVGF_STATE;
     lvg.state = LVGS_COLLAPSIBLE;
     if (collapsed)
@@ -419,24 +414,7 @@ void ListView::Sort(int sort_column, int sort_order, int type,
   sort_column_ = sort_column;
   sort_order_ = (sort_order == 0) ? 1 : sort_order;
   sort_type_ = type;
-
   ListView_SortItemsEx(window_, compare, this);
-
-  if (GetVersion() < kVersionVista) {
-    HDITEM hdi = {0};
-    hdi.mask = HDI_FORMAT;
-
-    HWND header = ListView_GetHeader(window_);
-    for (int i = 0; i < Header_GetItemCount(header); ++i) {
-      Header_GetItem(header, i, &hdi);
-      hdi.fmt &= ~(HDF_SORTDOWN | HDF_SORTUP);
-      Header_SetItem(header, i, &hdi);
-    }
-
-    Header_GetItem(header, sort_column, &hdi);
-    hdi.fmt |= (sort_order > -1 ? HDF_SORTUP : HDF_SORTDOWN);
-    Header_SetItem(header, sort_column, &hdi);
-  }
 }
 
 }  // namespace win

--- a/win/taskbar.cpp
+++ b/win/taskbar.cpp
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 #include "taskbar.h"
-#include "version.h"
 
 const DWORD WM_TASKBARCALLBACK = WM_APP + 0x15;
 const DWORD WM_TASKBARCREATED = ::RegisterWindowMessage(L"TaskbarCreated");
@@ -33,14 +32,7 @@ namespace win {
 
 Taskbar::Taskbar()
     : hwnd_(nullptr) {
-  Version version = GetVersion();
-  if (version >= kVersionVista) {
-    data_.cbSize = sizeof(NOTIFYICONDATA);
-  } else if (version >= kVersionXp) {
-    data_.cbSize = NOTIFYICONDATA_V3_SIZE;
-  } else {
-    data_.cbSize = NOTIFYICONDATA_V2_SIZE;
-  }
+  data_.cbSize = sizeof(data_);
 }
 
 Taskbar::~Taskbar() {

--- a/win/version.cpp
+++ b/win/version.cpp
@@ -22,18 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include <windows.h>
-
 #include "version.h"
 
 namespace win {
 
 // We can't expect that the compiler has VersionHelpers.h,
 // so use our own functions to check the Windows version.
-// An underscore added to avoid name collision.
-inline bool _IsWindowsVersionOrGreater(WORD major, WORD minor) {
+inline bool IsWindowsVersionOrGreater(WORD major, WORD minor, WORD build) {
   OSVERSIONINFOEXW vi = { sizeof(vi),
-                          major, minor, 0, 0, {0}, 0 };
+                          major, minor, build, 0, {0}, 0 };
   return ::VerifyVersionInfoW(&vi,
             VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
             ::VerSetConditionMask(::VerSetConditionMask(::VerSetConditionMask(0,
@@ -42,7 +39,7 @@ inline bool _IsWindowsVersionOrGreater(WORD major, WORD minor) {
                                       VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL));
 }
 
-inline bool _IsWindowsServer() {
+inline bool IsWindowsServer() {
   OSVERSIONINFOEXW vi = { sizeof(vi),
                           0, 0, 0, 0, {0}, 0, 0, 0, VER_NT_WORKSTATION };
   return !::VerifyVersionInfoW(&vi, VER_PRODUCT_TYPE,
@@ -56,20 +53,16 @@ Version GetVersion() {
   if (checked)
     return version;
 
-  if (_IsWindowsVersionOrGreater(10, 0))
+  if (IsWindowsVersionOrGreater(10, 0))
     version = kVersion10;
-  else if (_IsWindowsVersionOrGreater(6, 3))
+  else if (IsWindowsVersionOrGreater(6, 3))
     version = kVersion8_1;
-  else if (_IsWindowsVersionOrGreater(6, 2))
+  else if (IsWindowsVersionOrGreater(6, 2))
     version = kVersion8;
-  else if (_IsWindowsVersionOrGreater(6, 1))
+  else if (IsWindowsVersionOrGreater(6, 1))
     version = kVersion7;
-  else if (_IsWindowsVersionOrGreater(6, 0))
-    version = _IsWindowsServer() ? kVersionServer2008 : kVersionVista;
-  else if (_IsWindowsVersionOrGreater(5, 1))
-    version = _IsWindowsServer() ? kVersionServer2003 : kVersionXp;
-  else if (_IsWindowsVersionOrGreater(5, 0))
-    version = kVersion2000;
+  else if (IsWindowsVersionOrGreater(6, 0))
+    version = kVersionVista;
 
   checked = true;
   return version;

--- a/win/version.h
+++ b/win/version.h
@@ -24,21 +24,21 @@ SOFTWARE.
 
 #pragma once
 
+#include <windows.h>
+
 namespace win {
 
 enum Version {
   kVersionUnknown = 0,
-  kVersion2000,
-  kVersionXp,
-  kVersionServer2003,
   kVersionVista,
-  kVersionServer2008,
   kVersion7,
   kVersion8,
   kVersion8_1,
   kVersion10,
 };
 
+inline bool IsWindowsVersionOrGreater(WORD major, WORD minor, WORD build = 0);
+inline bool IsWindowsServer();
 Version GetVersion();
 
 }  // namespace win

--- a/win/version.h
+++ b/win/version.h
@@ -27,7 +27,8 @@ SOFTWARE.
 namespace win {
 
 enum Version {
-  kVersionPreXp = 0,
+  kVersionUnknown = 0,
+  kVersion2000,
   kVersionXp,
   kVersionServer2003,
   kVersionVista,
@@ -36,7 +37,6 @@ enum Version {
   kVersion8,
   kVersion8_1,
   kVersion10,
-  kVersionUnknown
 };
 
 Version GetVersion();


### PR DESCRIPTION
dialog.cpp, window.cpp:
----------------------
Added `common.h` with defined `WM_MOUSEHWHEEL`, since it is only defined when `_WIN32_WINNT` >= 0x0600 (Vista or later) and in theory the program can be compiled on Windows XP, and this event should work on Windows Vista and later.

version.h, version.cpp:
----------------------
`GetVersionEx` is deprecated and shouldn't be used since Windows 8.1, changed the function to use `VerifyVersionInfo`. I don't use `VersionHelpers.h` because it isn't available on all platforms.
See more info here:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx
https://msdn.microsoft.com/en-us/library/windows/desktop/dn424972(v=vs.85).aspx

Added `kVersion2000` version type;
Replaced `kVersionPreXp` with `kVersionUnknown`;

Now `kVersionUnknown` is returned only when Windows is older than Win2000.
We can't expect `kVersionUnknown` when MajorNumber>10 (Windows 11?).
Simple check `if (version >= kVersion10)` is enough, we can't use `kVersionUnknown` to check for Win11+, what if Microsoft will release Windows 11 with Major.Minor=10.1, then the function would return `kVersion10` instead of supposed `kVersionUnknown`.

Added `GetDllVersion` function to check the version of system .dll if it provides the `DllGetVersion` function. Needed in taskbar.cpp

taskbar.cpp:
-----------
Changed the way of getting correct `data_.cbSize` according to MSDN:
see Remarks section:
https://msdn.microsoft.com/en-us/library/windows/desktop/bb773352(v=vs.85).aspx

Whether `NOTIFYICONDATA_V2_SIZE` and `NOTIFYICONDATA_V3_SIZE` are defined depends on `WINVER` and `_WIN32_WINNT` values, so use the preprocessor guards here.
`NOTIFYICONDATA_V1_SIZE` should always be defined.