### PR TITLE
Silence compilation warnings with Clang

### DIFF
--- a/win/dialog.h
+++ b/win/dialog.h
@@ -71,6 +71,8 @@ protected:
   virtual INT_PTR DialogProcDefault(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 private:
+  using Window::Create; // Hide Create method from the base class
+
   static INT_PTR CALLBACK DialogProcStatic(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
   void SetMinMaxInfo(LPMINMAXINFO mmi);

--- a/win/window.cpp
+++ b/win/window.cpp
@@ -236,7 +236,8 @@ void Window::CenterOwner() {
   }
 
   HMONITOR monitor = ::MonitorFromWindow(window_, MONITOR_DEFAULTTONEAREST);
-  MONITORINFO mi = { sizeof(mi), 0 };
+  MONITORINFO mi = {0};
+  mi.cbSize = sizeof(mi);
   if (::GetMonitorInfo(monitor, &mi)) {
     rc_desktop = mi.rcWork;
     if (!parent_)


### PR DESCRIPTION
`Create` method in public section of `Dialog` class redefines the `Create` method from `Window` class with different parameters.
Silence the warning by declaring the `Window` class `Create` method in private section.

There was a warning about using `0` instead of `{0}` as a second parameter of `MONITORINFO`