### PR TITLE
Fix snapping to edges

### DIFF
--- a/win/dialog.h
+++ b/win/dialog.h
@@ -74,10 +74,12 @@ private:
   static INT_PTR CALLBACK DialogProcStatic(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
   void SetMinMaxInfo(LPMINMAXINFO mmi);
-  void SnapToEdges(LPWINDOWPOS window_pos);
+  bool SnapToEdges(LPRECT rc);
 
   bool  modal_;
-  int   snap_gap_;
+  bool  moving_;
+  bool  snapped_;
+  int   snap_gap_, snap_dx_, snap_dy_;
   SIZE  size_last_, size_max_, size_min_;
   POINT pos_last_;
 };


### PR DESCRIPTION
Currently it was broken due to invisible borders around windows on Win10, also there were some other minor issues with unsnapping. Also the aero snapping wasn't taken into account too.

The current code is the full copy of my mpv snapping code mpv-player/mpv#3890, with one small fix.

The program should be linked with Dwmapi.dll (Dwmapi.lib)